### PR TITLE
Fix Bootstrap Configuration `@runtime_libs` path.

### DIFF
--- a/elixir_runtime/lib/mix/tasks/bootstrap.ex
+++ b/elixir_runtime/lib/mix/tasks/bootstrap.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Bootstrap do
 
   use Mix.Task
 
-  @runtime_libs "elixir_runtime-0.1.0/priv"
+  @runtime_libs "aws_lambda_elixir_runtime-0.1.1/priv"
 
   @shortdoc "Generate a bootstrap script for the project"
   def run(_) do

--- a/elixir_runtime/mix.exs
+++ b/elixir_runtime/mix.exs
@@ -7,7 +7,7 @@ defmodule Lambda.MixProject do
   def project do
     [
       app: :aws_lambda_elixir_runtime,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
*Issue #, if available:*
No Issue

*Description of changes:*
Fix runtime path causing lambda deploys to crash using the examples in the README. As a note, this is so the example works as expected. It would still be best practice to create a CloudFormation configuration to deploy the dependencies as a Layer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
